### PR TITLE
Resolve 'Error: invalid byte sequence in US-ASCII'

### DIFF
--- a/templates/avahi-daemon.conf.erb
+++ b/templates/avahi-daemon.conf.erb
@@ -1,5 +1,5 @@
 #
-# MANAGED BY PUPPET – Modification is futile!
+# MANAGED BY PUPPET - Modification is futile!
 #
 # See avahi-daemon.conf(5) for more information on this configuration
 # file!


### PR DESCRIPTION
The dash in the top comment of the file is UTF-8, causing my Puppet to error out with 'Error: invalid byte sequence in US-ASCII'. The rest of the file is ASCII, so just replacing it with an actual dash fixes this.
